### PR TITLE
feat(errors): implement taxonomy and cli handling

### DIFF
--- a/app/errors/__init__.py
+++ b/app/errors/__init__.py
@@ -31,12 +31,38 @@ Non-goals
 ===============================================================================
 """
 
-# Codex should implement the re-exports AFTER implementing codes/exceptions/handlers.
-# from .codes import ErrorCode
-# from .exceptions import (
-#     AppError,
-#     ConfigError, DBConnectionError, DBMigrationError, DBOperationError,
-#     ValidationError, NotFoundError, ConflictError,
-#     ExternalServiceError, TimeoutError, IOErrorApp, UnknownError,
-# )
-# from .handlers import map_exception, handle_cli_error, wrap_cli_main
+from .codes import ErrorCode
+from .exceptions import (
+    AppError,
+    ConfigError,
+    ConflictError,
+    DBConnectionError,
+    DBMigrationError,
+    DBOperationError,
+    ExternalServiceError,
+    IOErrorApp,
+    NotFoundError,
+    TimeoutError,
+    UnknownError,
+    ValidationError,
+)
+from .handlers import handle_cli_error, map_exception, wrap_cli_main
+
+__all__: list[str] = [
+    "ErrorCode",
+    "AppError",
+    "ConfigError",
+    "DBConnectionError",
+    "DBMigrationError",
+    "DBOperationError",
+    "ValidationError",
+    "NotFoundError",
+    "ConflictError",
+    "ExternalServiceError",
+    "TimeoutError",
+    "IOErrorApp",
+    "UnknownError",
+    "map_exception",
+    "handle_cli_error",
+    "wrap_cli_main",
+]

--- a/app/errors/codes.py
+++ b/app/errors/codes.py
@@ -29,9 +29,135 @@ What Codex must implement
     IO_ERROR             = ("SENG-IO-001", 74, "ERROR", 500)
     UNKNOWN_ERROR        = ("SENG-UNKNOWN-000", 1, "CRITICAL", 500)
 
+Implementation pattern (no ambiguity)
+------------------------------------
+- Implement ErrorCode as an `enum.Enum` where each member value is a 4-tuple
+  `(code, exit_code, severity, http_status)`. Provide typed properties so
+  usage is ergonomic:
+
+    class ErrorCode(Enum):
+        CONFIG_ERROR = ("SENG-CONFIG-001", 78, "ERROR", 400)
+        ...
+
+        @property
+        def code(self) -> str: ...
+        @property
+        def exit_code(self) -> int: ...
+        @property
+        def severity(self) -> Literal["INFO","WARN","ERROR","CRITICAL"]: ...
+        @property
+        def http_status(self) -> int | None: ...
+
+- Export: `__all__ = ["ErrorCode"]`
+
 Notes
 -----
 - Codes are **stable** once released; new conditions get new codes.
 - Exit codes follow sysexits-like semantics where reasonable.
 ===============================================================================
 """
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Literal
+
+SeverityLiteral = Literal["INFO", "WARN", "ERROR", "CRITICAL"]
+
+
+class ErrorCode(Enum):
+    """Canonical catalog of Scheduling Engine error codes."""
+
+    CONFIG_ERROR = (
+        "SENG-CONFIG-001",
+        78,
+        "ERROR",
+        400,
+    )
+    DB_CONNECTION_ERROR = (
+        "SENG-DB-001",
+        65,
+        "CRITICAL",
+        503,
+    )
+    DB_MIGRATION_ERROR = (
+        "SENG-DB-002",
+        65,
+        "ERROR",
+        500,
+    )
+    DB_OPERATION_ERROR = (
+        "SENG-DB-003",
+        65,
+        "ERROR",
+        500,
+    )
+    VALIDATION_ERROR = (
+        "SENG-VALIDATION-001",
+        64,
+        "ERROR",
+        422,
+    )
+    NOT_FOUND_ERROR = (
+        "SENG-DOMAIN-001",
+        66,
+        "ERROR",
+        404,
+    )
+    CONFLICT_ERROR = (
+        "SENG-DOMAIN-002",
+        69,
+        "ERROR",
+        409,
+    )
+    EXTERNAL_SERVICE_ERROR = (
+        "SENG-EXT-001",
+        70,
+        "ERROR",
+        502,
+    )
+    TIMEOUT_ERROR = (
+        "SENG-EXT-002",
+        75,
+        "ERROR",
+        504,
+    )
+    IO_ERROR = (
+        "SENG-IO-001",
+        74,
+        "ERROR",
+        500,
+    )
+    UNKNOWN_ERROR = (
+        "SENG-UNKNOWN-000",
+        1,
+        "CRITICAL",
+        500,
+    )
+
+    @property
+    def code(self) -> str:
+        """Return the stable string identifier for this error code."""
+
+        return self.value[0]
+
+    @property
+    def exit_code(self) -> int:
+        """Return the CLI exit status associated with this error."""
+
+        return self.value[1]
+
+    @property
+    def severity(self) -> SeverityLiteral:
+        """Return the default severity for this error type."""
+
+        return self.value[2]
+
+    @property
+    def http_status(self) -> int | None:
+        """Return the HTTP status mapped to this error, if defined."""
+
+        return self.value[3]
+
+
+__all__ = ["ErrorCode"]

--- a/app/errors/exceptions.py
+++ b/app/errors/exceptions.py
@@ -22,6 +22,8 @@ What Codex must implement
     ValidationError, NotFoundError, ConflictError, ExternalServiceError,
     TimeoutError, IOErrorApp, UnknownError
 
+  Use subclass name `IOErrorApp` deliberately to avoid clashing with built-in `IOError` alias of `OSError`.
+
   Each subclass:
     - Sets default `code`, `exit_code`, `severity` from ErrorCode catalog.
     - Accepts `message: str | None` (fallback to a sensible default).
@@ -31,9 +33,293 @@ What Codex must implement
     def from_exception(exc: BaseException) -> AppError
       (optional—can live in handlers instead)
 
+- Export `__all__ = ["AppError","ConfigError","DBConnectionError","DBMigrationError",
+                     "DBOperationError","ValidationError","NotFoundError","ConflictError",
+                     "ExternalServiceError","TimeoutError","IOErrorApp","UnknownError"]`
+
+- `message` must default to a sensible constant per subclass if not provided.
+- `context` type: `Mapping[str, object] | None` for read-only safety; store internally as `dict[str, object]`.
+- `__str__` returns `"<code> <message>"`; avoid leaking context in `str()`; leave it to logs.
+
 Notes
 -----
 - Keep messages succinct and actionable.
 - Do not embed secrets in messages or context.
+- `repr(AppError)` and messages must not include secrets (DB URLs, tokens). If needed, redact with "***".
 ===============================================================================
 """
+
+from __future__ import annotations
+
+from typing import Mapping, MutableMapping, Optional
+
+from .codes import ErrorCode, SeverityLiteral
+
+
+class AppError(Exception):
+    """Base class for all Scheduling Engine application errors."""
+
+    code: str
+    message: str
+    context: MutableMapping[str, object] | None
+    exit_code: int
+    severity: SeverityLiteral
+
+    def __init__(
+        self,
+        *,
+        code: str,
+        message: str,
+        exit_code: int,
+        severity: SeverityLiteral,
+        context: Mapping[str, object] | None = None,
+    ) -> None:
+        """Initialize the application error with structured metadata."""
+
+        super().__init__(f"{code} {message}")
+        self.code = code
+        self.message = message
+        self.exit_code = exit_code
+        self.severity = severity
+        self.context = dict(context) if context else None
+
+    def __str__(self) -> str:
+        """Return a concise representation used for CLI and logs."""
+
+        return f"{self.code} {self.message}"
+
+
+class ConfigError(AppError):
+    """Raised when configuration files or environment values are invalid."""
+
+    DEFAULT_MESSAGE = "Invalid configuration detected."
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        context: Mapping[str, object] | None = None,
+    ) -> None:
+        code = ErrorCode.CONFIG_ERROR
+        super().__init__(
+            code=code.code,
+            message=message or self.DEFAULT_MESSAGE,
+            exit_code=code.exit_code,
+            severity=code.severity,
+            context=context,
+        )
+
+
+class DBConnectionError(AppError):
+    """Raised when the application cannot reach the database server."""
+
+    DEFAULT_MESSAGE = "Unable to connect to the database."
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        context: Mapping[str, object] | None = None,
+    ) -> None:
+        code = ErrorCode.DB_CONNECTION_ERROR
+        super().__init__(
+            code=code.code,
+            message=message or self.DEFAULT_MESSAGE,
+            exit_code=code.exit_code,
+            severity=code.severity,
+            context=context,
+        )
+
+
+class DBMigrationError(AppError):
+    """Raised when database migrations fail to complete successfully."""
+
+    DEFAULT_MESSAGE = "Database migration failed."
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        context: Mapping[str, object] | None = None,
+    ) -> None:
+        code = ErrorCode.DB_MIGRATION_ERROR
+        super().__init__(
+            code=code.code,
+            message=message or self.DEFAULT_MESSAGE,
+            exit_code=code.exit_code,
+            severity=code.severity,
+            context=context,
+        )
+
+
+class DBOperationError(AppError):
+    """Raised when a database operation encounters an error."""
+
+    DEFAULT_MESSAGE = "Database operation failed."
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        context: Mapping[str, object] | None = None,
+    ) -> None:
+        code = ErrorCode.DB_OPERATION_ERROR
+        super().__init__(
+            code=code.code,
+            message=message or self.DEFAULT_MESSAGE,
+            exit_code=code.exit_code,
+            severity=code.severity,
+            context=context,
+        )
+
+
+class ValidationError(AppError):
+    """Raised when user input or state validation fails."""
+
+    DEFAULT_MESSAGE = "Validation failed."
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        context: Mapping[str, object] | None = None,
+    ) -> None:
+        code = ErrorCode.VALIDATION_ERROR
+        super().__init__(
+            code=code.code,
+            message=message or self.DEFAULT_MESSAGE,
+            exit_code=code.exit_code,
+            severity=code.severity,
+            context=context,
+        )
+
+
+class NotFoundError(AppError):
+    """Raised when the requested resource does not exist."""
+
+    DEFAULT_MESSAGE = "Requested resource was not found."
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        context: Mapping[str, object] | None = None,
+    ) -> None:
+        code = ErrorCode.NOT_FOUND_ERROR
+        super().__init__(
+            code=code.code,
+            message=message or self.DEFAULT_MESSAGE,
+            exit_code=code.exit_code,
+            severity=code.severity,
+            context=context,
+        )
+
+
+class ConflictError(AppError):
+    """Raised when a domain conflict prevents the requested action."""
+
+    DEFAULT_MESSAGE = "Resource conflict detected."
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        context: Mapping[str, object] | None = None,
+    ) -> None:
+        code = ErrorCode.CONFLICT_ERROR
+        super().__init__(
+            code=code.code,
+            message=message or self.DEFAULT_MESSAGE,
+            exit_code=code.exit_code,
+            severity=code.severity,
+            context=context,
+        )
+
+
+class ExternalServiceError(AppError):
+    """Raised when a downstream service returns an error."""
+
+    DEFAULT_MESSAGE = "External service returned an error."
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        context: Mapping[str, object] | None = None,
+    ) -> None:
+        code = ErrorCode.EXTERNAL_SERVICE_ERROR
+        super().__init__(
+            code=code.code,
+            message=message or self.DEFAULT_MESSAGE,
+            exit_code=code.exit_code,
+            severity=code.severity,
+            context=context,
+        )
+
+
+class TimeoutError(AppError):
+    """Raised when an operation exceeds the allotted time budget."""
+
+    DEFAULT_MESSAGE = "Operation timed out."
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        context: Mapping[str, object] | None = None,
+    ) -> None:
+        code = ErrorCode.TIMEOUT_ERROR
+        super().__init__(
+            code=code.code,
+            message=message or self.DEFAULT_MESSAGE,
+            exit_code=code.exit_code,
+            severity=code.severity,
+            context=context,
+        )
+
+
+class IOErrorApp(AppError):
+    """Raised when file system or IO interactions fail."""
+
+    DEFAULT_MESSAGE = "Input/output operation failed."
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        context: Mapping[str, object] | None = None,
+    ) -> None:
+        code = ErrorCode.IO_ERROR
+        super().__init__(
+            code=code.code,
+            message=message or self.DEFAULT_MESSAGE,
+            exit_code=code.exit_code,
+            severity=code.severity,
+            context=context,
+        )
+
+
+class UnknownError(AppError):
+    """Raised when an unexpected or unmapped error occurs."""
+
+    DEFAULT_MESSAGE = "An unexpected error occurred."
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        context: Mapping[str, object] | None = None,
+    ) -> None:
+        code = ErrorCode.UNKNOWN_ERROR
+        super().__init__(
+            code=code.code,
+            message=message or self.DEFAULT_MESSAGE,
+            exit_code=code.exit_code,
+            severity=code.severity,
+            context=context,
+        )
+
+
+__all__ = [
+    "AppError",
+    "ConfigError",
+    "DBConnectionError",
+    "DBMigrationError",
+    "DBOperationError",
+    "ValidationError",
+    "NotFoundError",
+    "ConflictError",
+    "ExternalServiceError",
+    "TimeoutError",
+    "IOErrorApp",
+    "UnknownError",
+]


### PR DESCRIPTION
## Summary
- define the ErrorCode enum with canonical identifiers, severities, and exit codes
- add the AppError base type with concrete subclasses that bind error metadata
- implement CLI-safe exception normalization, logging, and decorator utilities, then re-export the package API

## Testing
- black app/errors
- ruff check app/errors
- mypy --config-file mypy.ini app/errors

------
https://chatgpt.com/codex/tasks/task_e_68d4c418bef08325952913c7b4784816