### PR TITLE
feat: add database foundation

### DIFF
--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -2,13 +2,23 @@
 ===============================================================================
 Package: app.db
 Purpose:
-  Database access layer integration point. Exports get_engine() and SessionLocal,
-  and central metadata for Alembic usage.
-
-Exports:
-  - get_engine(), SessionLocal, get_session()
-
-Collaborators:
-  - .engine, .session, .base (metadata), .healthcheck, .seed
+  Database access layer integration point. Re-exports engine/session helpers.
 ===============================================================================
 """
+
+from __future__ import annotations
+
+from .base import Base, import_all_models, metadata
+from .engine import create_engine_from_settings, sanitize_url_for_log
+from .session import create_session_factory, get_session, session_scope
+
+__all__ = [
+    "create_engine_from_settings",
+    "sanitize_url_for_log",
+    "create_session_factory",
+    "get_session",
+    "session_scope",
+    "Base",
+    "metadata",
+    "import_all_models",
+]

--- a/app/db/alembic_env.py
+++ b/app/db/alembic_env.py
@@ -2,154 +2,58 @@
 ===============================================================================
 File: app/db/alembic_env.py
 Purpose:
-  Alembic environment script (project-specific). It wires Alembic to our
-  SQLAlchemy metadata and runtime settings so `alembic upgrade head`
-  operates on the correct database and sees all models.
-
-Outcomes Codex must deliver
----------------------------
-1) **Online mode only** (we do not generate offline SQL files yet).
-2) Load settings from our app config (Pydantic Settings), resolving DB URL as:
-     - If `DATABASE_URL` is set: use it.
-     - Else compose from parts: DB_USER/DB_PASSWORD/DB_HOST/DB_PORT/DB_NAME.
-3) Import `Base` metadata from `app.db.base` and set:
-     target_metadata = Base.metadata
-   Ensure models are imported first by calling `import_all_models()`.
-4) Create an Engine with:
-     future=True, pool_pre_ping=True
-   and pass it to Alembic's migration context for online migrations.
-5) Set safe Postgres session guards prior to running migrations:
-     SET lock_timeout = '5s';
-     SET statement_timeout = '60s';
-   (Execute via connection before `context.run_migrations()`.)
-6) Support both CLI invocation (`alembic upgrade head`) and programmatic use.
-7) Avoid importing the entire app graph; only import minimal settings + base.
-8) Ensure that the first entity `organisations` (Organisation model in
-   app.models.core) is visible after calling `import_all_models()` so
-   autogenerate can create the table per ERD.
-
-Required functions / structure
-------------------------------
-- Provide `run_migrations_online()` which:
-    * loads settings
-    * builds SQLAlchemy Engine
-    * configures Alembic context with `target_metadata`
-    * executes the timeout `SET` statements
-    * runs migrations inside a transaction block
-
-- Provide a no-op `run_migrations_offline()` that raises NotImplementedError
-  (document that we only support online mode for now).
-
-Pathing & imports
------------------
-- Ensure sys.path includes the repository root so `import app...` works when
-  Alembic invokes this script from the repo root.
-- Alembic `script_location` is `migrations/` (set in alembic.ini). If an
-  Alembic-generated `migrations/env.py` exists, it should simply import and
-  delegate to `run_migrations_online()` from this module.
-
-Postgres specifics & notes
---------------------------
-- For large indexes, prefer CREATE INDEX CONCURRENTLY (separate transaction).
-- Search path: start with `public` schema only.
-
-Collaborators
--------------
-- app.config.settings : Pydantic Settings factory (get_settings()).
-- app.db.base         : Base/metadata and `import_all_models()`.
-- alembic.ini         : provides script location & logging config.
-
+  Alembic environment script (project-specific) for running migrations online.
 ===============================================================================
 """
 
 from __future__ import annotations
 
-import os
+import pathlib
 import sys
-from logging.config import fileConfig
+from typing import Final
 
 from alembic import context
-from sqlalchemy import create_engine, pool
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
 
-# Import Base/metadata for target_metadata (imports must be at top for Ruff E402)
-from app.db.base import Base, import_all_models
+REPO_ROOT: Final[pathlib.Path] = pathlib.Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
-# Ensure sys.path includes repo root for `import app...`
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+from app.config.settings import get_settings  # noqa: E402
+from app.db.base import Base, import_all_models  # noqa: E402
 
-# Alembic Config object, for logging etc.
-config = context.config
-if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+__all__ = ["run_migrations_online", "run_migrations_offline", "target_metadata"]
 
-# Ensure models are imported so Alembic autogenerate can see them
-import_all_models()
 target_metadata = Base.metadata
 
 
-def _get_database_url() -> str:
-    """
-    Resolve the database URL from environment or app settings.
-    Precedence:
-      1) OS env DATABASE_URL
-      2) Compose from DB_USER/DB_PASSWORD/DB_HOST/DB_PORT/DB_NAME via settings
-    """
-    # 1) Try direct env
-    direct = os.getenv("DATABASE_URL")
-    if direct:
-        return direct
+def _configure_engine(url: str) -> Engine:
+    """Return a SQLAlchemy engine configured for Alembic migrations."""
 
-    # 2) Use app settings (preferred path in dev/test)
-    from importlib import import_module
-
-    s = getattr(import_module("app.config.settings"), "get_settings")()
-    # If settings object already exposes DATABASE_URL, prefer it
-    url = getattr(s, "DATABASE_URL", None)
-    if isinstance(url, str) and url:
-        return url
-
-    user = getattr(s, "DB_USER", None)
-    pw = getattr(s, "DB_PASSWORD", None)
-    host = getattr(s, "DB_HOST", None)
-    port = getattr(s, "DB_PORT", None)
-    name = getattr(s, "DB_NAME", None)
-    if all([user, pw, host, port, name]):
-        return f"postgresql+psycopg2://{user}:{pw}@{host}:{port}/{name}"
-
-    raise RuntimeError("Could not resolve database URL from environment or settings")
+    return create_engine(url, pool_pre_ping=True, future=True)
 
 
 def run_migrations_online() -> None:
-    """
-    Run Alembic migrations in 'online' mode.
-    """
-    connectable = create_engine(
-        _get_database_url(),
-        poolclass=pool.NullPool,
-        future=True,
-        pool_pre_ping=True,
-    )
+    """Run Alembic migrations in online mode against the configured database."""
 
-    with connectable.connect() as connection:
-        # Set Postgres session timeouts for safe migrations
-        connection.exec_driver_sql("SET lock_timeout = '5s'")
-        connection.exec_driver_sql("SET statement_timeout = '60s'")
+    settings = get_settings()
+    database_url = settings.effective_database_url
+    engine = _configure_engine(database_url)
 
-        context.configure(
-            connection=connection,
-            target_metadata=target_metadata,
-            compare_type=True,
-            compare_server_default=True,
-        )
-
+    with engine.connect() as connection:
+        import_all_models()
+        context.configure(connection=connection, target_metadata=target_metadata)
+        connection.execute(text("SET lock_timeout = '5s'"))
+        connection.execute(text("SET statement_timeout = '60s'"))
         with context.begin_transaction():
             context.run_migrations()
+    engine.dispose()
 
 
 def run_migrations_offline() -> None:
-    """
-    Offline mode is not supported. Use online migrations only.
-    """
+    """Offline migrations are not supported for this project."""
+
     raise NotImplementedError(
-        "Offline migrations are not supported. Run in online mode."
+        "Offline migrations are not supported; use online mode only."
     )

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -3,83 +3,19 @@
 File: app/db/base.py
 Purpose:
   Expose the canonical SQLAlchemy declarative base (`Base`) and metadata for the app.
-  All models must inherit from this Base. Alembic uses `target_metadata = Base.metadata`.
-
-Outcomes Codex must deliver
----------------------------
-1) Define a declarative Base with a **stable naming convention** so Alembic
-   autogenerate produces consistent constraint/index names.
-2) Expose `Base` and `Base.metadata` (the latter is Alembic's `target_metadata`).
-3) Provide a no-op function `import_all_models()` that, when called, imports
-   all ORM model modules (e.g., app.models.*) exactly once so that
-   `Base.metadata` is fully populated before Alembic autogenerate runs.
-4) Keep this module side-effect free (do NOT import models at import time).
-   Alembic env will call `import_all_models()` explicitly.
-
-Required implementation details
--------------------------------
-- Use SQLAlchemy **2.x** APIs.
-- __tablename__ explicitly set for each model
-- id columns: UUID or BIGSERIAL (project decision); organisations.id = UUID v4 (recommended)
-- timestamps: created_at, updated_at in UTC (DB default or app-managed)
-- Construct `Base` via `declarative_base()` using a `MetaData` object with the
-  following naming convention:
-    pk: pk_%(table_name)s
-    fk: fk_%(table_name)s_%(referred_table_name)s_%(column_0_name)s
-    ix: ix_%(table_name)s_%(column_0_name)s
-    uq: uq_%(table_name)s_%(column_0_name)s
-    ck: ck_%(table_name)s_%(constraint_name)s
-- Export:
-    Base                # the declarative base class
-    metadata            # alias to Base.metadata
-    import_all_models   # function to import app models
-
-Guidance for future models (context for Codex)
-----------------------------------------------
-- We’ll initially mirror the ERD for `organisations` exactly (INTEGER/SERIAL PK).
-  Later entities may move to UUID v4 PKs with `gen_random_uuid()` (pgcrypto).
-- Store timestamps in UTC (`timezone=True`); convert to Australia/Melbourne in app.
-
-Visibility to Alembic
----------------------
-- app/db/alembic_env.py must import `from app.db.base import Base` and set:
-    target_metadata = Base.metadata
-- Ensure models are imported somewhere under app/models/__init__.py so Alembic
-  autogenerate can discover them (import side-effects ONLY in alembic env).
-
-Collaborators
--------------
-- app/models/* : concrete ORM models; keep imports centralized via
-  the `import_all_models()` function to avoid circular imports.
-- app/db/alembic_env.py : calls `import_all_models()` before autogenerate.
-
-Non-goals
----------
-- Do NOT emit any DDL or connect to the database here.
-- Do NOT auto-import model modules at import time.
-
-Testing
--------
-- Smoke: target_metadata is a sqlalchemy MetaData instance.
-- Migration diff: running `alembic revision --autogenerate` sees model tables.
-
-Notes
------
-- Keep this module side-effect free (no Engine creation, no Session).
 ===============================================================================
 """
 
 from __future__ import annotations
 
-import importlib
-import pkgutil
 from typing import Final
 
-from sqlalchemy import MetaData
-from sqlalchemy.orm import declarative_base
+import sqlalchemy as sa
+from sqlalchemy.orm import DeclarativeBase
 
-# Stable naming convention for Alembic/autogenerate
-NAMING_CONVENTION: Final = {
+__all__ = ["Base", "metadata", "import_all_models"]
+
+_NAMING_CONVENTION: Final[dict[str, str]] = {
     "pk": "pk_%(table_name)s",
     "fk": "fk_%(table_name)s_%(referred_table_name)s_%(column_0_name)s",
     "ix": "ix_%(table_name)s_%(column_0_name)s",
@@ -87,22 +23,27 @@ NAMING_CONVENTION: Final = {
     "ck": "ck_%(table_name)s_%(constraint_name)s",
 }
 
-metadata = MetaData(naming_convention=NAMING_CONVENTION)
-Base = declarative_base(metadata=metadata)
+_metadata = sa.MetaData(naming_convention=_NAMING_CONVENTION)
+
+
+class Base(DeclarativeBase):
+    """Declarative base class that all ORM models must inherit from."""
+
+    metadata = _metadata
+
+
+metadata = Base.metadata
+
+_MODELS_IMPORTED: bool = False
 
 
 def import_all_models() -> None:
-    """
-    Import all ORM models to ensure Base.metadata is fully populated.
-    Call this before Alembic autogenerate or any metadata-based operations.
+    """Import all ORM model modules so ``Base.metadata`` is populated."""
 
-    Implementation notes:
-    - Dynamically import all submodules under `app.models`.
-    - Keep this a no-op if called multiple times (Python import system ensures that).
-    """
-    import app.models as models_pkg  # local import to avoid cycles
+    global _MODELS_IMPORTED
+    if _MODELS_IMPORTED:
+        return
 
-    for _, modname, _ in pkgutil.iter_modules(
-        models_pkg.__path__, models_pkg.__name__ + "."
-    ):
-        importlib.import_module(modname)
+    import app.models.core  # noqa: F401
+
+    _MODELS_IMPORTED = True

--- a/app/db/engine.py
+++ b/app/db/engine.py
@@ -5,85 +5,172 @@ Purpose
 -------
 Create and manage the canonical SQLAlchemy **Engine** for Postgres.
 Enforce safe defaults (timeouts, pooling, pre-ping, redaction) and provide
-helpers for building sanitized URLs for logs. The engine is used by:
-- healthcheck (read-only ping)
-- session factory (transactions, repositories)
-- CLI commands (init-db, seed-data, diag, check-env)
-- Alembic (via separate alembic.ini path, not this module)
-
-Public API (Codex must implement)
----------------------------------
-1) def create_engine_from_settings(
-       settings,
-       *,
-       echo_sql: bool | None = None,
-       role: str = "app",
-       statement_timeout_ms: int | None = 5000,
-       idle_in_tx_timeout_ms: int | None = 120000,
-       connect_timeout_s: int | None = 5,
-   ) -> "sqlalchemy.Engine":
-   Behavior:
-   - Build an Engine for Postgres using an **effective URL** from `settings`:
-       * Prefer settings.DATABASE_URL when provided (must be "postgresql+psycopg2://...")
-       * Else compose from parts (DB_USER, DB_PASSWORD, DB_HOST, DB_PORT, DB_NAME)
-   - Safe defaults:
-       * pool_pre_ping=True (detect dead connections)
-       * pool_size=5 (dev/test), max_overflow=5, pool_timeout=10, pool_recycle=1800
-       * echo=echo_sql if provided else (True only when APP_ENV=="dev" and LOG_LEVEL=="DEBUG")
-       * future=True (if using SQLAlchemy 2.x style)
-   - connect_args (psycopg2):
-       * "connect_timeout": connect_timeout_s (default 5)
-       * "application_name": f"{settings.APP_NAME}:{role}"
-       * optionally "options": f"-c statement_timeout={statement_timeout_ms} -c idle_in_transaction_session_timeout={idle_in_tx_timeout_ms}"
-         (Only include clauses that are not None)
-   - MUST NOT log unsanitized URLs (use sanitizer below).
-   - Return the Engine instance.
-
-2) def sanitize_url_for_log(url: str) -> str
-   - Redact credentials in a Postgres URL:
-       "postgresql+psycopg2://user:pass@host:5432/db" -> "postgresql+psycopg2://***:***@host:5432/db"
-   - Keep scheme/host/port/dbname intact for troubleshooting.
-
-3) Optional: def engine_diagnostics(engine) -> dict
-   - Return simple, **non-connecting** metadata about the engine configuration:
-     {"pool_size": int, "max_overflow": int, "echo": bool, "dialect": "postgresql+psycopg2"}
-   - MUST NOT connect to the DB just to compute diagnostics.
-
-Safety & timeouts
------------------
-- Use `pool_pre_ping=True` to detect stale connections.
-- Enforce driver-level **connect_timeout** via connect_args.
-- Prefer **server-side** statement timeouts via the "options" string:
-    -c statement_timeout=5000
-    -c idle_in_transaction_session_timeout=120000
-- These timeouts apply per-connection; callers may still enforce higher-level timeouts.
-
-Environment & settings contract (read-only)
--------------------------------------------
-- settings.effective_database_url (property or method; see settings.py)
-- settings.APP_ENV, settings.APP_NAME, settings.LOG_LEVEL
-- Optional: settings.DB_* parts when composing URL
-
-Logging & redaction
--------------------
-- This module must not log secrets. If it logs the URL, always use `sanitize_url_for_log`.
-- Final logging formatting is handled by app.config.logging_config filters (trace_id, env, redaction).
-
-Integration
------------
-- Used by healthcheck.ping(engine) (read-only)
-- Used by session factory (see app/db/session.py)
-- CLI init-db/seed-data/diag/check-env call this to get an Engine.
-
-Testing
--------
-- Unit (no DB): constructing engine with composed URL; `sanitize_url_for_log` correctness.
-- Integration (test DB): engine connects and works with healthcheck.ping()
-  respecting timeouts (no mutation).
-
-Non-goals
----------
-- No async engine in v1.
-- No engine caching/global singleton here; the caller (CLI/run.py) stores it.
+helpers for building sanitized URLs for logs.
 ===============================================================================
 """
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine, make_url
+
+__all__ = [
+    "create_engine_from_settings",
+    "sanitize_url_for_log",
+    "engine_diagnostics",
+]
+
+
+def sanitize_url_for_log(url: str) -> str:
+    """Return a redacted representation of a Postgres connection URL.
+
+    Parameters
+    ----------
+    url:
+        Raw connection string that may include credentials.
+
+    Returns
+    -------
+    str
+        A safe URL representation where the username and password (if
+        present) are replaced with ``***`` so secrets never appear in logs.
+    """
+
+    try:
+        sa_url = make_url(url)
+    except Exception:
+        return "***"
+    username = "***" if sa_url.username else None
+    password = "***" if sa_url.password else None
+    redacted = sa_url.set(username=username, password=password)
+    return str(redacted)
+
+
+def _build_connect_args(
+    *,
+    settings: Any,
+    role: str,
+    statement_timeout_ms: int | None,
+    idle_in_tx_timeout_ms: int | None,
+    connect_timeout_s: int | None,
+) -> dict[str, Any]:
+    """Construct psycopg2 ``connect_args`` enforcing timeout safeguards."""
+    connect_args: dict[str, Any] = {
+        "application_name": f"{settings.APP_NAME}:{role}",
+    }
+    if connect_timeout_s is not None:
+        connect_args["connect_timeout"] = connect_timeout_s
+
+    option_parts: list[str] = []
+    if statement_timeout_ms is not None:
+        option_parts.append(f"-c statement_timeout={statement_timeout_ms}")
+    if idle_in_tx_timeout_ms is not None:
+        option_parts.append(
+            f"-c idle_in_transaction_session_timeout={idle_in_tx_timeout_ms}"
+        )
+    if option_parts:
+        connect_args["options"] = " ".join(option_parts)
+    return connect_args
+
+
+def create_engine_from_settings(
+    settings: Any,
+    *,
+    echo_sql: bool | None = None,
+    role: str = "app",
+    statement_timeout_ms: int | None = 5000,
+    idle_in_tx_timeout_ms: int | None = 120000,
+    connect_timeout_s: int | None = 5,
+) -> Engine:
+    """Build and return a configured SQLAlchemy engine for Postgres.
+
+    Parameters
+    ----------
+    settings:
+        Pydantic settings instance exposing ``effective_database_url``,
+        environment flags, and app metadata.
+    echo_sql:
+        Optional override for SQLAlchemy's ``echo`` flag. When ``None`` the
+        value is derived from ``APP_ENV`` and ``LOG_LEVEL``.
+    role:
+        Identifier appended to ``application_name`` for easier attribution in
+        Postgres activity views.
+    statement_timeout_ms / idle_in_tx_timeout_ms / connect_timeout_s:
+        Driver-level guards applied to every connection to prevent runaway
+        queries and stalled transactions.
+
+    Returns
+    -------
+    Engine
+        A fully configured SQLAlchemy engine that has not established any
+        connections yet.
+    """
+
+    effective_url = settings.effective_database_url
+    echo = (
+        echo_sql
+        if echo_sql is not None
+        else settings.APP_ENV == "dev" and settings.LOG_LEVEL == "DEBUG"
+    )
+
+    engine = create_engine(
+        effective_url,
+        echo=echo,
+        pool_pre_ping=True,
+        pool_size=5,
+        max_overflow=5,
+        pool_timeout=10,
+        pool_recycle=1800,
+        connect_args=_build_connect_args(
+            settings=settings,
+            role=role,
+            statement_timeout_ms=statement_timeout_ms,
+            idle_in_tx_timeout_ms=idle_in_tx_timeout_ms,
+            connect_timeout_s=connect_timeout_s,
+        ),
+    )
+    return engine
+
+
+def engine_diagnostics(engine: Engine) -> dict[str, Any]:
+    """Return non-connecting diagnostic information about an engine.
+
+    Parameters
+    ----------
+    engine:
+        Engine instance to introspect.
+
+    Returns
+    -------
+    dict[str, Any]
+        Lightweight metadata describing pool sizing, echo flag, and dialect
+        without requiring an actual database connection.
+    """
+
+    pool = engine.pool
+    pool_size_value: Any
+    size_attr = getattr(pool, "size", None)
+    if callable(size_attr):
+        try:
+            pool_size_value = size_attr()
+        except TypeError:
+            pool_size_value = None
+    else:
+        pool_size_value = size_attr
+    max_overflow_value = getattr(pool, "max_overflow", None)
+    if callable(max_overflow_value):
+        try:
+            max_overflow_value = max_overflow_value()
+        except TypeError:
+            max_overflow_value = None
+    if max_overflow_value is None:
+        max_overflow_value = getattr(pool, "_max_overflow", None)
+
+    return {
+        "pool_size": pool_size_value,
+        "max_overflow": max_overflow_value,
+        "echo": bool(engine.echo),
+        "dialect": f"{engine.dialect.name}+{engine.dialect.driver}",
+    }

--- a/app/db/seed.py
+++ b/app/db/seed.py
@@ -3,107 +3,183 @@
 File: app/db/seed.py
 Purpose
 -------
-Provide **deterministic, idempotent** seed routines for development & test
-databases. Seeding must be safe to run multiple times and should never duplicate
-rows. All writes occur inside a single transaction that either fully commits or
-rolls back.
-
-Scope (v1)
-----------
-- Minimal dataset to validate the pipeline end-to-end using the **organisations**
-  table as the first entity scope.
-- Additional seeders may be added later as separate functions.
-
-Public API (Codex must implement)
----------------------------------
-def seed_minimal(session, *, org_name: str | None = None) -> dict:
-    Idempotently ensure the presence of a single 'organisation' record, plus
-    any trivial referential prerequisites (none in v1).
-    - session: SQLAlchemy Session (already opened by caller).
-    - org_name: Optional explicit organisation name. Defaults to "Whiteline Demo".
-    Returns:
-      {
-        "inserted": int,   # rows inserted
-        "updated": int,    # rows updated in-place
-        "skipped": int,    # rows already present & unchanged
-        "items": [         # optional details (may be omitted for perf)
-          {"id": "<uuid>", "name": "...", "slug": "..."}
-        ],
-      }
-    Contract:
-      - Must be **idempotent**: running repeatedly yields "skipped" after first run.
-      - Must be **deterministic**: same inputs -> same outputs.
-      - Must perform only necessary writes (no churn on timestamps unless changed).
-    Error policy:
-      - Do not swallow DB exceptions. Let IntegrityError/OperationalError bubble.
-      - Higher layers (CLI) map exceptions to AppError via handlers.
-
-def seed_from_plan(session, plan: "SeedPlan") -> dict:
-    General-purpose entry that executes a declarative plan object (see SeedPlan
-    below). Enables composing multiple seed operations while preserving
-    idempotence, single-transaction semantics, and a unified summary.
-
-# Optional type to make plans explicit (simple dataclass / NamedTuple)
-class SeedPlan:
-    Represents a declarative, ordered set of seed tasks.
-    Fields:
-      organisations: list[OrganisationSeed]
-      # Future: teams, venues, seasons, fixtures...
-
-class OrganisationSeed:
-    DTO describing an organisation to ensure exists.
-    Fields:
-      name: str             # business key (unique)
-      slug: str | None      # optional; when absent, derive from name
-
-Implementation notes
---------------------
-- Use OrganisationRepository for all DB access.
-- Generate/normalize slug using the same rules as our DTOs (schemas/organisation.py).
-- Upsert strategy (portable v1):
-    * get_by_name() -> if found and fields differ, update (only changed fields)
-    * else create()
-- Ensure you **refresh()** after create/update to return current row state.
-
-Transaction model
------------------
-- Caller opens a Session (context-managed). This module does not manage commits.
-- The CLI (`seed-data --apply`) wraps seed_minimal() within one transaction.
-- On any exception, callers must rollback and map errors at the boundary.
-
-Safety & side effects
----------------------
-- No destructive operations (no truncates / deletes) in v1 seeders.
-- No logging here; the CLI prints a single structured summary line.
-- No secret values anywhere.
-
-Validation
-----------
-- Reject empty `org_name` after stripping; raise ValueError prior to DB work.
-- Ensure slug normalization yields a valid slug; if impossible, raise ValueError.
-
-Performance
------------
-- Seed should complete in < 100 ms for a warm connection.
-- Avoid N+1; one lookup + create/update per entity is sufficient.
-
-Testing expectations
---------------------
-- First run: returns {"inserted": 1, "updated": 0, "skipped": 0}
-- Second run (same inputs): {"inserted": 0, "updated": 0, "skipped": 1}
-- Change org_name to an existing record name → conflict surfaces as IntegrityError
-  (when slug collides); the CLI maps this to ConflictError (exit 69).
-- With explicit slug: upsert respects provided slug (normalized).
-
-Dependencies
-------------
-- app.repositories.organisation_repository.OrganisationRepository
-- app.schemas.organisation.OrganisationInDTO / normalizers (for slug derivation)
-- app.db.session.get_session (used by the CLI, not here)
-
-Extensibility (future)
-----------------------
-- Add additional seeders: teams, venues, seasons...
-- Introduce reproducible **fixture sets** keyed by environment (dev/test/demo).
+Deterministic, idempotent seed routines for development and test databases.
 ===============================================================================
 """
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.repositories.organisation_repository import OrganisationRepository
+from app.schemas.organisation import OrganisationInDTO
+
+__all__ = ["OrganisationSeed", "SeedPlan", "seed_minimal", "seed_from_plan"]
+
+_DEFAULT_ORG_NAME = "Whiteline Demo"
+_SLUG_SANITISE_RE = re.compile(r"[^a-z0-9]+")
+
+
+@dataclass(frozen=True, slots=True)
+class OrganisationSeed:
+    """Declarative description of an organisation to ensure exists."""
+
+    name: str
+    slug: str | None = None
+
+
+@dataclass(slots=True)
+class SeedPlan:
+    """Container for ordered seed tasks."""
+
+    organisations: tuple[OrganisationSeed, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:  # noqa: D401 - docstring inherited from class
+        """Normalise the organisations collection to an immutable tuple."""
+
+        if not isinstance(self.organisations, tuple):
+            self.organisations = tuple(self.organisations)
+
+
+def _fallback_normalize_slug(value: str) -> str:
+    """Best-effort slug normaliser mirroring DTO behaviour."""
+
+    slug = _SLUG_SANITISE_RE.sub("-", value.lower()).strip("-")
+    slug = re.sub(r"-+", "-", slug)
+    if not slug:
+        raise ValueError("Unable to derive slug from organisation name")
+    return slug
+
+
+def _normalize_inputs(name: str, slug: str | None) -> tuple[str, str]:
+    """Validate and normalise organisation name/slug values via DTO rules."""
+
+    dto = OrganisationInDTO(name=name, slug=slug)
+    normalised_name = dto.name
+    derived_slug = dto.slug
+    if not derived_slug:
+        normaliser = getattr(OrganisationInDTO, "normalize_slug", None)
+        if callable(normaliser):
+            derived_slug = normaliser(normalised_name)
+        else:
+            derived_slug = _fallback_normalize_slug(normalised_name)
+    return normalised_name, derived_slug
+
+
+def _get_attr(entity: Any, *candidates: str) -> Any:
+    for candidate in candidates:
+        if hasattr(entity, candidate):
+            return getattr(entity, candidate)
+    return None
+
+
+def _summarise_org(entity: Any) -> dict[str, Any]:
+    identifier = _get_attr(entity, "id", "organisation_id")
+    name_value = _get_attr(entity, "name", "organisation_name")
+    slug_value = _get_attr(entity, "slug", "organisation_slug")
+    return {
+        "id": str(identifier) if identifier is not None else None,
+        "name": name_value,
+        "slug": slug_value,
+    }
+
+
+def _ensure_organisation(
+    session: Session,
+    repository: OrganisationRepository,
+    *,
+    name: str,
+    slug: str | None,
+) -> tuple[str, Any]:
+    """Insert or update an organisation record, returning the resulting action."""
+
+    normalised_name, normalised_slug = _normalize_inputs(name, slug)
+    existing = repository.get_by_name(session, normalised_name)
+    if existing is None:
+        created = repository.create(session, name=normalised_name, slug=normalised_slug)
+        session.flush()
+        session.refresh(created)
+        return "inserted", created
+
+    updates: dict[str, str] = {}
+    current_name = _get_attr(existing, "name", "organisation_name")
+    if current_name != normalised_name:
+        updates["name"] = normalised_name
+    current_slug = _get_attr(existing, "slug", "organisation_slug")
+    if current_slug != normalised_slug:
+        updates["slug"] = normalised_slug
+
+    if updates:
+        identifier = _get_attr(existing, "id", "organisation_id")
+        if identifier is None:
+            raise ValueError("Organisation row is missing a primary key identifier")
+        updated = repository.update(session, identifier, **updates)
+        session.flush()
+        session.refresh(updated)
+        return "updated", updated
+
+    return "skipped", existing
+
+
+def seed_minimal(session: Session, *, org_name: str | None = None) -> dict[str, Any]:
+    """Ensure the presence of a single demonstration organisation.
+
+    Parameters
+    ----------
+    session:
+        Active SQLAlchemy session opened by the caller.
+    org_name:
+        Optional explicit organisation name. When omitted the default
+        ``Whiteline Demo`` name is used.
+
+    Returns
+    -------
+    dict[str, Any]
+        Summary containing ``inserted``, ``updated``, ``skipped`` counters and
+        a list of affected organisation descriptors.
+    """
+
+    base_name = org_name if org_name is not None else _DEFAULT_ORG_NAME
+    effective_name = base_name.strip()
+    if not effective_name:
+        raise ValueError("Organisation name must not be empty")
+
+    plan = SeedPlan(organisations=(OrganisationSeed(name=effective_name),))
+    return seed_from_plan(session, plan)
+
+
+def seed_from_plan(session: Session, plan: SeedPlan) -> dict[str, Any]:
+    """Execute the provided seed plan within the caller's transaction.
+
+    Parameters
+    ----------
+    session:
+        Active SQLAlchemy session supplied by the caller.
+    plan:
+        Declarative plan containing the entities that must exist.
+
+    Returns
+    -------
+    dict[str, Any]
+        Aggregated summary of insert/update/skip counts and entity descriptors.
+    """
+
+    repository = OrganisationRepository()
+    counts: dict[str, int] = {"inserted": 0, "updated": 0, "skipped": 0}
+    items: list[dict[str, Any]] = []
+
+    for org_seed in plan.organisations:
+        action, entity = _ensure_organisation(
+            session,
+            repository,
+            name=org_seed.name,
+            slug=org_seed.slug,
+        )
+        counts[action] += 1
+        items.append(_summarise_org(entity))
+
+    return {**counts, "items": items}


### PR DESCRIPTION
## Summary
- add a configurable Postgres engine factory with sanitized logging helpers
- expose session factory utilities and shared declarative metadata for models
- wire Alembic, healthcheck ping, and deterministic seed plan utilities

## Testing
- ruff check
- pytest
- mypy app *(fails: mypy.ini patterns for psycopg are not fully qualified)*

------
https://chatgpt.com/codex/tasks/task_e_68d4cf9db8848325bc51ffc80aee096b