### PR TITLE
feat: add organisation model and dto layer

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,24 +1,23 @@
-"""
-===============================================================================
-Package: app.models
-Purpose:
-  House all ORM model modules. Alembic visibility is achieved by dynamically
-  importing these modules via `app.db.base.import_all_models()` before
-  autogenerate runs.
+"""app.models package
+=====================
 
-Guidelines
-----------
-- DO NOT eagerly import models here (avoid side effects).
-- Each model module should import Base from app.db.base and declare ORM classes.
-- Optionally maintain __all__ for discoverability (not required for Alembic).
-
-First visible entity
---------------------
-- organisations (see app.models.core.Organisation)
-===============================================================================
+Container package for SQLAlchemy ORM models. Modules are imported lazily to
+avoid side effects during package import while still giving Alembic visibility
+via :func:`app.db.base.import_all_models`.
 """
 
-# Optional export list (informational; not required for Alembic)
-__all__: list[str] = [
-    # "Organisation",  # uncomment if you want explicit exports later
-]
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+__all__ = ["Organisation"]
+
+
+def __getattr__(name: str) -> Any:
+    """Provide lazy access to ORM classes without eager imports."""
+
+    if name == "Organisation":
+        module = import_module("app.models.core")
+        return getattr(module, name)
+    raise AttributeError(f"module 'app.models' has no attribute {name!r}")

--- a/app/models/core.py
+++ b/app/models/core.py
@@ -1,78 +1,44 @@
-"""
-===============================================================================
-File: app/models/core.py
-Purpose:
-  Define the first concrete ORM entity for visibility & migration validation.
+"""app.models.core
+===================
 
-Entity Scope (from database_erd.md)
------------------------------------
-TABLE: organisations
-PURPOSE: Tenant boundary; top-level owner of competitions/venues.
-
-Columns (mirror ERD exactly for v1)
------------------------------------
-- organisation_id : INTEGER PRIMARY KEY (SERIAL in ERD)
-    - SQLAlchemy: Integer, primary_key=True, autoincrement=True
-- organisation_name : TEXT NOT NULL
-    - Unique constraint (alternate key in ERD) → enforce UNIQUE
-- time_zone : TEXT NULL
-- country_code : TEXT NULL
-- created_at : TIMESTAMPTZ NULL DEFAULT now()
-    - Model: timezone-aware DateTime (timezone=True) with server_default=sa.text("now()")
-- created_by_user_id : INTEGER NOT NULL  (FK → users(user_account_id))
-    - Index on (created_by_user_id) as per ERD
-    - FK addition may be deferred if the users table is not yet present in this service.
-      If users table is outside this service scope, create as a plain Integer + index now,
-      and add the FK constraint in a later revision when the users table is available.
-
-Modeling Requirements
----------------------
-- Use SQLAlchemy **2.x** Declarative with type annotations.
-- `__tablename__ = "organisations"`.
-- Column names should match the ERD names exactly for easier SQL parity.
-- Add a __repr__ helper with key fields for debugging.
-- Do NOT import Base at module import time from anywhere other than app.db.base.
-  (Correct import: `from app.db.base import Base`.)
-
-Indexes & Constraints
----------------------
-- UNIQUE(organisation_name)
-- INDEX(created_by_user_id) named via naming convention (ix_organisations_created_by_user_id)
-- Optional: future functional index LOWER(organisation_name) if case-insensitive search is needed.
-
-Migration Expectations (autogenerate)
--------------------------------------
-- Alembic autogenerate should create:
-  - organisations table with the above columns & constraints
-  - unique constraint on organisation_name
-  - btree index on created_by_user_id
-  - (FK only if users table is present; otherwise omit FK now to avoid broken refs)
-- No data seeding in this initial revision.
-
-Testing Notes
--------------
-- Integration test should SELECT current_database() and ensure table exists once migrations are applied.
-- Repository smoke test can insert/select/rollback using db_session fixture when enabled.
-
-Dependencies
-------------
-- app.db.base.Base  (Declarative Base)
-- SQLAlchemy 2.x (sqlalchemy and sqlalchemy.orm)
-===============================================================================
+SQLAlchemy ORM models for the Scheduling Engine prototype. This module
+currently exposes the :class:`Organisation` entity which mirrors the ERD's
+``organisations`` table and enables Alembic autogeneration to detect schema
+changes during the initial development phase.
 """
 
 from __future__ import annotations
 
+from datetime import datetime
+
 import sqlalchemy as sa
+from sqlalchemy import UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
 
+__all__ = ["Organisation"]
+
 
 class Organisation(Base):
-    """
-    ORM class for `organisations` matching the ERD.
-    See header block for full specification and migration expectations.
+    """Concrete ORM mapping for the ``organisations`` table.
+
+    Attributes
+    ----------
+    organisation_id:
+        Surrogate primary key that auto-increments.
+    organisation_name:
+        Unique, human-readable name of the organisation.
+    time_zone / country_code:
+        Optional descriptive metadata matching the ERD specification.
+    created_at / updated_at:
+        Server managed timestamps (UTC) used for auditing.
+    created_by_user_id:
+        Identifier of the user that provisioned the organisation. The foreign
+        key constraint is deferred until the ``users`` table becomes available
+        within this service boundary.
+    slug:
+        Stable unique identifier suitable for CLI usage and URLs.
     """
 
     __tablename__ = "organisations"
@@ -83,22 +49,35 @@ class Organisation(Base):
     organisation_name: Mapped[str] = mapped_column(sa.Text, nullable=False)
     time_zone: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
     country_code: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
-    created_at: Mapped["sa.DateTime"] = mapped_column(
+    created_at: Mapped[datetime | None] = mapped_column(
         sa.DateTime(timezone=True),
         server_default=sa.text("now()"),
-        nullable=True,  # ERD marks NULLABLE; keep parity for v1
+        nullable=True,
     )
     created_by_user_id: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+    slug: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    updated_at: Mapped[datetime | None] = mapped_column(
+        sa.DateTime(timezone=True),
+        server_default=sa.text("now()"),
+        onupdate=sa.text("now()"),
+        nullable=True,
+    )
 
     __table_args__ = (
-        sa.UniqueConstraint("organisation_name"),
+        UniqueConstraint(
+            "organisation_name", name="uq_organisations_organisation_name"
+        ),
+        UniqueConstraint("slug", name="uq_organisations_slug"),
         sa.Index("ix_organisations_created_by_user_id", "created_by_user_id"),
-        # FK deferred until users table exists locally; enable later:
-        # sa.ForeignKeyConstraint(["created_by_user_id"], ["users.user_account_id"]),
     )
 
     def __repr__(self) -> str:
+        """Return a helpful representation for debugging and logging."""
+
         return (
-            f"Organisation(id={self.organisation_id!r}, "
-            f"name={self.organisation_name!r}, tz={self.time_zone!r})"
+            "Organisation("
+            f"id={self.organisation_id!r}, "
+            f"name={self.organisation_name!r}, "
+            f"slug={self.slug!r}"
+            ")"
         )

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,43 +1,33 @@
-"""
-===============================================================================
-Package: app.schemas
-Purpose
--------
-Define **DTOs** (Data Transfer Objects) used at boundaries:
-- CLI/diagnostics outputs (e.g., check-env, diag, seed summaries)
-- Service/repository input/output shapes (e.g., organisations CRUD)
-- Healthcheck/infra summaries
+"""Top-level exports for schema DTOs used by the Scheduling Engine."""
 
-Design rules (Pydantic v2)
---------------------------
-- Pydantic BaseModel used for all DTOs.
-- **Snake_case** in Python; **JSON** also snake_case (no aliasing required in v1).
-- Datetimes are timezone-aware UTC (ISO8601 with "Z" when serialized).
-- UUIDs serialized as standard strings.
-- No ORM objects leak outside: use explicit mapping functions.
+from __future__ import annotations
 
-Module layout
--------------
-- common.py       : shared types, base config, helpers (timestamps, pagination,
-                    healthcheck payload, error envelope)
-- organisation.py : DTOs specific to organisations CRUD/listing (entity scope #1)
-
-Export contract (Codex must implement)
---------------------------------------
 from .common import (
     BaseDTO,
-    TimestampsDTO,
-    PaginationQuery,
-    PaginationMeta,
-    SortQuery,
-    HealthcheckPingDTO,
     ErrorEnvelopeDTO,
+    HealthcheckPingDTO,
+    PaginationMeta,
+    PaginationQuery,
+    SortQuery,
+    TimestampsDTO,
 )
 from .organisation import (
     OrganisationInDTO,
-    OrganisationUpdateDTO,
-    OrganisationOutDTO,
     OrganisationListOutDTO,
+    OrganisationOutDTO,
+    OrganisationUpdateDTO,
 )
-===============================================================================
-"""
+
+__all__ = [
+    "BaseDTO",
+    "ErrorEnvelopeDTO",
+    "HealthcheckPingDTO",
+    "PaginationMeta",
+    "PaginationQuery",
+    "SortQuery",
+    "TimestampsDTO",
+    "OrganisationInDTO",
+    "OrganisationListOutDTO",
+    "OrganisationOutDTO",
+    "OrganisationUpdateDTO",
+]

--- a/app/schemas/common.py
+++ b/app/schemas/common.py
@@ -1,84 +1,148 @@
-"""
-===============================================================================
-File: app/schemas/common.py
-Purpose
--------
-Provide **shared DTO primitives** and configuration for all schemas:
-- Base model config (Pydantic v2)
-- Timestamps mixin (created_at, updated_at)
-- Pagination + sorting query objects and response metadata
-- Healthcheck ping payload (for check-env/diag)
-- Error envelope for consistent machine output (future HTTP compatibility)
+"""Shared DTO primitives and helpers for the Scheduling Engine."""
 
-Pydantic v2 configuration (Codex must implement)
-------------------------------------------------
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Literal, cast
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+__all__ = [
+    "BaseDTO",
+    "TimestampsDTO",
+    "PaginationQuery",
+    "PaginationMeta",
+    "SortQuery",
+    "HealthcheckPingDTO",
+    "ErrorEnvelopeDTO",
+    "ensure_utc",
+    "now_utc",
+    "to_json",
+]
+
+
 class BaseDTO(BaseModel):
+    """Base class for all DTOs with project-wide configuration."""
+
     model_config = ConfigDict(
-        frozen=False,               # DTOs are mutable by default
-        extra="forbid",             # reject unknown fields
-        populate_by_name=False,     # we keep snake_case everywhere in v1
-        str_strip_whitespace=True,  # trim strings
-        validate_default=True,      # validate defaults
+        frozen=False,
+        extra="forbid",
+        populate_by_name=False,
+        str_strip_whitespace=True,
+        validate_default=True,
         ser_json_timedelta="iso8601",
-        ser_json_inf_nan=False,
+        ser_json_inf_nan=cast(Any, False),
     )
 
-UTC datetime policy
--------------------
-- All datetimes are **aware** in UTC.
-- Serializer must produce ISO8601 with "Z".
-- Provide validators/helpers:
-    - def ensure_utc(dt: datetime) -> datetime
-    - @field_validator("created_at", "updated_at", mode="before") to coerce to UTC
 
-DTO primitives (Codex must implement)
--------------------------------------
-1) class TimestampsDTO(BaseDTO):
-       created_at: datetime
-       updated_at: datetime
-   - Validators ensure both are UTC-aware.
+def now_utc() -> datetime:
+    """Return the current UTC time as an aware :class:`datetime`."""
 
-2) class PaginationQuery(BaseDTO):
-       page: int = 1
-       page_size: int = 50
-       sort: str | None = None   # e.g., "name", "-created_at"
-       search: str | None = None
-   - Validate: page >= 1, 1 <= page_size <= 100 (raise ValueError otherwise).
+    return datetime.now(timezone.utc)
 
-3) class PaginationMeta(BaseDTO):
-       page: int
-       page_size: int
-       total: int
 
-4) class SortQuery(BaseDTO):
-       sort: str | None = None
-   - Placeholder type (some commands may only accept sorting).
+def ensure_utc(value: datetime | str) -> datetime:
+    """Coerce a datetime-like value to a timezone-aware UTC datetime."""
 
-5) class HealthcheckPingDTO(BaseDTO):
-       ok: bool
-       database: str
-       server_version: str
-       duration_ms: float
-   - **Exact** keys/types match Phase H Step 17.
-   - Provide @classmethod from_dict(d: dict) -> "HealthcheckPingDTO" for adapter.
+    if isinstance(value, str):
+        value = value.strip()
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        try:
+            parsed = datetime.fromisoformat(value)
+        except ValueError as exc:  # pragma: no cover - defensive branch
+            raise ValueError("Invalid datetime string") from exc
+        value = parsed
 
-6) class ErrorEnvelopeDTO(BaseDTO):
-       code: str                 # e.g., "SENG-DB-001"
-       message: str              # safe, user-facing error
-       exit_code: int
-       severity: Literal["INFO","WARN","ERROR","CRITICAL"]
-       context: dict[str, object] | None = None
+    if not isinstance(value, datetime):
+        raise TypeError("Expected datetime or ISO8601 string")
 
-Mapping helpers (non-ORM specific)
-----------------------------------
-- def to_json(obj: BaseDTO) -> str: JSON dumps with the correct config.
-- Optional: def now_utc() -> datetime for convenience in DTO factories.
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
 
-Testing expectations
---------------------
-- Pagination validation (boundaries enforced).
-- Timestamps are UTC-aware after model creation.
-- HealthcheckPingDTO.from_dict returns a valid DTO with correct types.
-- ErrorEnvelopeDTO round-trips to JSON cleanly.
-===============================================================================
-"""
+
+class TimestampsDTO(BaseDTO):
+    """Mixin providing UTC-aware creation and update timestamps."""
+
+    created_at: datetime
+    updated_at: datetime
+
+    @field_validator("created_at", "updated_at", mode="before")
+    @classmethod
+    def _coerce_utc(cls, value: datetime | str) -> datetime:
+        """Ensure stored timestamps are normalized to UTC."""
+
+        return ensure_utc(value)
+
+
+class PaginationQuery(BaseDTO):
+    """Pagination inputs used by list-style repository queries."""
+
+    page: int = 1
+    page_size: int = 50
+    sort: str | None = None
+    search: str | None = None
+
+    @field_validator("page")
+    @classmethod
+    def _validate_page(cls, value: int) -> int:
+        """Validate that the page number is at least one."""
+
+        if value < 1:
+            raise ValueError("page must be greater than or equal to 1")
+        return value
+
+    @field_validator("page_size")
+    @classmethod
+    def _validate_page_size(cls, value: int) -> int:
+        """Validate the configured page size is within accepted bounds."""
+
+        if not 1 <= value <= 100:
+            raise ValueError("page_size must be between 1 and 100")
+        return value
+
+
+class PaginationMeta(BaseDTO):
+    """Metadata describing the pagination state for list responses."""
+
+    page: int
+    page_size: int
+    total: int
+
+
+class SortQuery(BaseDTO):
+    """Sorting-only query payload used by some CLI commands."""
+
+    sort: str | None = None
+
+
+class HealthcheckPingDTO(BaseDTO):
+    """Structured payload returned by the healthcheck diagnostic command."""
+
+    ok: bool
+    database: str
+    server_version: str
+    duration_ms: float
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "HealthcheckPingDTO":
+        """Build an instance from a mapping produced by adapters."""
+
+        return cls.model_validate(payload)
+
+
+class ErrorEnvelopeDTO(BaseDTO):
+    """Machine-readable error contract used across CLI boundaries."""
+
+    code: str
+    message: str
+    exit_code: int
+    severity: Literal["INFO", "WARN", "ERROR", "CRITICAL"]
+    context: dict[str, object] | None = None
+
+
+def to_json(obj: BaseDTO) -> str:
+    """Serialise a DTO to JSON using the configured encoding rules."""
+
+    return obj.model_dump_json()


### PR DESCRIPTION
## Summary
- add the Organisation ORM mapping with UTC timestamp management, uniqueness constraints, and creator index
- expose models lazily from `app.models` to keep Alembic discovery side-effect free
- implement shared DTO primitives plus organisation DTOs with validation, slug normalisation, and repository mapping helpers

## Testing
- ruff check app/models/core.py app/schemas/common.py app/schemas/organisation.py
- mypy app/models/core.py app/schemas/common.py app/schemas/organisation.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4d6a14bbc83259bd8563906ce207f