### PR TITLE
feat: implement organisation repository layer

### DIFF
--- a/app/repositories/__init__.py
+++ b/app/repositories/__init__.py
@@ -1,41 +1,8 @@
-"""
-===============================================================================
-Package: app.repositories
-Purpose
--------
-Provide a thin, testable data-access layer over SQLAlchemy Sessions/Models.
-Repositories must:
-- Be **stateless** (no global session); accept a `Session` per-operation or at init.
-- Never create Engines/Sessions; callers provide them (see app.db.session).
-- Map low-level SQL/driver errors to **AppError** types at the CLI boundary only;
-  inside the repo, raise the original SQLAlchemy exceptions (so handlers can map).
+"""Repository package exports."""
 
-Repository design principles
-----------------------------
-- **Explicit Session**: Each method receives a `Session` (preferred) or the repo
-  is constructed with a `Session` to be used for the method lifetime.
-- **Idempotent Reads**: Reads never mutate state.
-- **Deterministic Writes**: Writes return the created/updated domain row (ORM object).
-- **UTC time**: Use app.utils.time helpers for timestamps; DB defaults preferred.
-- **No logging inside repositories**: Let callers log; repositories are pure access.
+from __future__ import annotations
 
-Error policy (alignment with Phase F Step 14)
----------------------------------------------
-- Repositories may catch IntegrityError/ProgrammingError to add context and re-raise
-  the **same** exception type (do NOT convert to AppError here). Handlers will map:
-  - IntegrityError (unique violation) → ConflictError
-  - ProgrammingError → DBOperationError
-  - OperationalError → DBConnectionError
+from app.repositories.base_repository import BaseRepository
+from app.repositories.organisation_repository import OrganisationRepository
 
-Testing conventions
--------------------
-- Unit (with test DB): Use transaction-per-test fixture; no state leakage.
-- Factories/fixtures create rows via repository methods to test constraints.
-- Assertions check DB state (counts, unique constraints, updates).
-
-Exports
--------
-- BaseRepository
-- OrganisationRepository
-===============================================================================
-"""
+__all__ = ["BaseRepository", "OrganisationRepository"]

--- a/app/repositories/base_repository.py
+++ b/app/repositories/base_repository.py
@@ -1,55 +1,163 @@
-"""
-===============================================================================
-File: app/repositories/base_repository.py
-Purpose
--------
-Provide shared helpers and a light contract for repository classes. This base
-does **not** manage sessions or transactions—callers do via app.db.session.
+"""Repository base utilities and shared helpers."""
 
-Public API (Codex must implement)
----------------------------------
+from __future__ import annotations
+
+from typing import Any, TypeVar
+
+from sqlalchemy import Select, func, select
+from sqlalchemy.orm import Session
+from sqlalchemy.sql import ColumnElement
+
+__all__ = ["BaseRepository"]
+
+_T = TypeVar("_T")
+
+
 class BaseRepository:
-    Base for repositories. Optionally holds a Session (when constructed with one),
-    but **each method** should also accept an explicit `session: Session` parameter
-    to keep usage flexible (pattern: prefer explicit `session` argument).
+    """Provide shared helpers for repository implementations."""
 
-    # Construction:
-    #   def __init__(self, session: Session | None = None):
-    #       self._session = session
+    def __init__(self, session: Session | None = None) -> None:
+        """Initialise the repository with an optional :class:`Session`."""
 
-    # Session accessor (helpers):
-    #   def require_session(self, session: Session | None) -> Session:
-    #       Return the explicit `session` if provided; else `self._session` if set;
-    #       otherwise raise RuntimeError("Session required").
+        self._session = session
 
-    # CRUD helper patterns (to be used by concrete repos):
-    #   - def add(self, session: Session, instance: Base) -> Base
-    #   - def delete(self, session: Session, instance: Base) -> None
-    #   - def refresh(self, session: Session, instance: Base) -> Base
+    def require_session(self, session: Session | None) -> Session:
+        """Return a usable :class:`~sqlalchemy.orm.Session` instance.
 
-    # Pagination utility:
-    #   def apply_pagination(self, query, *, page: int, page_size: int, max_page_size: int = 100) -> tuple[list, int]:
-    #       Enforce sane bounds (page>=1, 1<=page_size<=max_page_size).
-    #       Return (items, total_count). Use subquery or count() efficiently.
+        Parameters
+        ----------
+        session:
+            An explicit session provided by the caller. When ``None`` the
+            repository-level session (if configured) is used.
 
-    # Sorting utility:
-    #   def apply_sorting(self, query, *, sort: str | None, allowed: dict[str, ColumnElement]) -> Any:
-    #       Accept strings like "name" or "-created_at".
-    #       Map field names via `allowed` to actual columns; raise ValueError for invalid fields.
+        Raises
+        ------
+        RuntimeError
+            If no session is available.
+        """
 
-    # Existence/uniqueness helper:
-    #   def exists(self, session: Session, stmt) -> bool:
-    #       Efficient SQL EXISTS pattern.
+        if session is not None:
+            return session
+        if self._session is not None:
+            return self._session
+        raise RuntimeError("Session required")
 
-Contracts & safety
-------------------
-- Do **not** swallow SQLAlchemy exceptions; let them propagate.
-- Avoid N+1: when returning collections, eager-load relationships only when explicitly needed.
-- Sanitize/validate user input (sort fields, page sizes) at the repo boundary.
+    def add(self, session: Session, instance: _T) -> _T:
+        """Add an ORM instance to the identity map and return it."""
 
-Testing guidance
-----------------
-- Unit: feed a Session from a fixture; assert pagination and sorting.
-- Integration: verify constraints (unique keys) raise IntegrityError.
-===============================================================================
-"""
+        session.add(instance)
+        return instance
+
+    def delete(self, session: Session, instance: Any) -> None:
+        """Mark the provided ORM instance for deletion."""
+
+        session.delete(instance)
+
+    def refresh(self, session: Session, instance: _T) -> _T:
+        """Refresh an ORM instance from the database and return it."""
+
+        session.refresh(instance)
+        return instance
+
+    def apply_pagination(
+        self,
+        query: Select[Any],
+        *,
+        session: Session | None = None,
+        page: int,
+        page_size: int,
+        max_page_size: int = 100,
+    ) -> tuple[list[Any], int]:
+        """Apply pagination to ``query`` and return the paged items and total count.
+
+        Parameters
+        ----------
+        query:
+            The SQLAlchemy :class:`~sqlalchemy.sql.Select` object to paginate.
+        session:
+            Explicit session to use for execution. Falls back to the repository
+            session if omitted.
+        page:
+            One-based page index.
+        page_size:
+            Number of rows per page. Must be between 1 and ``max_page_size``.
+        max_page_size:
+            Upper bound for ``page_size`` to prevent unbounded queries.
+
+        Returns
+        -------
+        tuple[list[Any], int]
+            ``(items, total_count)`` where ``items`` are ORM objects produced by
+            the query and ``total_count`` represents the total number of rows
+            available without pagination.
+
+        Raises
+        ------
+        ValueError
+            If ``page`` or ``page_size`` fall outside the allowed bounds.
+        RuntimeError
+            When no session is available.
+        """
+
+        working_session = self.require_session(session)
+        if page < 1:
+            raise ValueError("page must be >= 1")
+        if page_size < 1:
+            raise ValueError("page_size must be >= 1")
+        if page_size > max_page_size:
+            raise ValueError("page_size exceeds maximum allowed value")
+
+        offset = (page - 1) * page_size
+        count_subquery = query.order_by(None).subquery()
+        total_stmt = select(func.count()).select_from(count_subquery)
+        total = int(working_session.execute(total_stmt).scalar_one())
+
+        paged_stmt = query.limit(page_size).offset(offset)
+        items = list(working_session.execute(paged_stmt).scalars().all())
+        return items, total
+
+    def apply_sorting(
+        self,
+        query: Select[Any],
+        *,
+        sort: str | None,
+        allowed: dict[str, ColumnElement[Any]],
+    ) -> Select[Any]:
+        """Apply ordering to ``query`` using an allowed mapping of sort keys.
+
+        Parameters
+        ----------
+        query:
+            The statement to modify.
+        sort:
+            Sort directive supplied by the caller. A leading ``-`` requests
+            descending order.
+        allowed:
+            Mapping of allowed sort keys to SQLAlchemy column expressions.
+
+        Returns
+        -------
+        Select[Any]
+            A new select with the appropriate ``ORDER BY`` clause applied.
+
+        Raises
+        ------
+        ValueError
+            If the provided ``sort`` value is not present in ``allowed``.
+        """
+
+        if sort is None:
+            return query
+        descending = sort.startswith("-")
+        field = sort[1:] if descending else sort
+        if field not in allowed:
+            raise ValueError(f"Invalid sort field: {field}")
+        column = allowed[field]
+        order_clause = column.desc() if descending else column.asc()
+        return query.order_by(order_clause)
+
+    def exists(self, session: Session, stmt: Select[Any]) -> bool:
+        """Return ``True`` when the provided statement yields at least one row."""
+
+        exists_stmt = select(stmt.exists())
+        return bool(session.execute(exists_stmt).scalar_one())


### PR DESCRIPTION
## Summary
- implement a typed BaseRepository with session helpers plus pagination, sorting, and existence utilities
- add an OrganisationRepository providing CRUD, search, pagination, and upsert behaviours
- expose repository classes from the package init for easier importing

## Testing
- poetry run black app/repositories/base_repository.py app/repositories/organisation_repository.py app/repositories/__init__.py
- poetry run ruff check app/repositories
- poetry run mypy app/repositories
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4ddbc5130832584c22b66ca82fae2