### PR TITLE
Add integration fixtures and database smoke tests

### DIFF
--- a/tests/integration/test_repositories.py
+++ b/tests/integration/test_repositories.py
@@ -1,54 +1,70 @@
-"""
-TEST DESCRIPTION BLOCK — tests/integration/test_repositories.py
+"""Repository integration tests exercising transactional behaviour."""
 
-Purpose
--------
-Exercise a minimal, end-to-end repository interaction with a **transactional Session**.
-Intended as a smoke-level integration test once a trivial model/table exists.
+from __future__ import annotations
 
-What to include
----------------
-1) Imports:
-   - stdlib: uuid
-   - third-party: pytest
-   - local: tests/fixtures/db.py (db_session), app.repositories.base_repository.BaseRepository
-           and possibly a simple concrete repository (e.g., OrganisationRepository) once available
-           plus ORM models from app.models.* if needed.
-
-2) Marker:
-   - @pytest.mark.integration
-
-3) Pre-conditions:
-   - A simple table/model with a primary key exists via migrations (e.g., organisations).
-   - Corresponding SQLAlchemy model and repository are implemented.
-
-4) Tests (examples; adjust to your first real entity):
-   - test_base_repository_session_lifecycle(db_session):
-       * Arrange: instantiate BaseRepository(db_session); execute a trivial SELECT 1 query via session.
-       * Assert: no exceptions; session is open during test and closed after.
-   - test_organisation_repository_roundtrip(db_session):
-       * Arrange: repo = OrganisationRepository(db_session)
-       * Act: create -> fetch -> assert fields -> delete (or rely on test rollback)
-       * Assert: fetched entity matches inserted data; repository methods behave.
-
-Constraints
------------
-- Rely on the per-test transaction rollback to avoid persistent writes.
-- Keep these tests minimal and stable; favor table-driven assertions.
-
-Dependencies on other scripts
------------------------------
-- app/repositories/base_repository.py
-- app/repositories/organisation_repository.py (or your first concrete repo)
-- app/models/core.py (and your first entity model)
-- tests/fixtures/db.py : db_session fixture
-
-Notes
------
-- Until a real model exists, you can keep this file with TODO tests or skipped tests.
-- Once the first model lands, enable real CRUD tests here.
-"""
+import uuid
 
 import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
 
-pytestmark = pytest.mark.skip(reason="Migrations not wired yet")
+from app.models.core import Organisation
+from app.repositories.base_repository import BaseRepository
+from app.repositories.organisation_repository import OrganisationRepository
+
+pytestmark = pytest.mark.integration
+
+
+def test_base_repository_session_lifecycle(db_session: Session) -> None:
+    """BaseRepository should reuse the provided session without closing it."""
+
+    repository = BaseRepository(db_session)
+    session = repository.require_session(None)
+    assert session is db_session
+    result = session.execute(text("select 1"))
+    assert result.scalar_one() == 1
+    assert session.is_active
+
+
+def test_organisation_repository_roundtrip(db_session: Session) -> None:
+    """Round-trip an organisation using the concrete repository implementation."""
+
+    repository = OrganisationRepository()
+    unique_suffix = uuid.uuid4().hex[:8]
+    name = f"Integration Club {unique_suffix}"
+    created = repository.create(db_session, name=name)
+    assert isinstance(created, Organisation)
+    assert created.organisation_id is not None
+    assert created.organisation_name == name
+    assert created.slug
+    assert created.created_at is not None
+    assert created.updated_at is not None
+    assert created.created_at.tzinfo is not None
+    assert created.updated_at.tzinfo is not None
+
+    fetched_by_id = repository.get_by_id(db_session, created.organisation_id)
+    assert fetched_by_id is not None
+    assert fetched_by_id.organisation_id == created.organisation_id
+
+    fetched_by_name = repository.get_by_name(db_session, name)
+    assert fetched_by_name is not None
+    assert fetched_by_name.organisation_id == created.organisation_id
+
+    fetched_by_slug = repository.get_by_slug(db_session, created.slug)
+    assert fetched_by_slug is not None
+    assert fetched_by_slug.organisation_id == created.organisation_id
+
+
+def test_organisation_repository_duplicate_name_raises(
+    db_session: Session,
+) -> None:
+    """Attempting to insert the same organisation twice should raise an error."""
+
+    repository = OrganisationRepository()
+    name = "Duplicate Integration Club"
+    first = repository.create(db_session, name=name)
+    assert first.organisation_id is not None
+    with pytest.raises(IntegrityError):
+        repository.create(db_session, name=name)
+    db_session.rollback()

--- a/tests/integration/test_seed_data.py
+++ b/tests/integration/test_seed_data.py
@@ -1,22 +1,68 @@
-"""
-TEST DESCRIPTION BLOCK — tests/integration/test_seed_data.py
+"""Integration tests covering deterministic database seed routines."""
 
-Purpose
--------
-Verify that the seed routines are deterministic, idempotent, and safe. Ensures
-the CLI wrapper (--dry-run / --apply) behaves per contract.
+from __future__ import annotations
 
-What to include
----------------
-- Fixtures: test engine + SessionLocal (transaction-per-test)
-- Test: first apply inserts; second apply skips
-- Test: dry-run predicts actions (mock or call seed_minimal in read-only mode)
-- Test: unique constraint behavior (two inserts with same name -> IntegrityError)
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
 
-Dependencies
-------------
-- app/db/seed.py
-- app/repositories/organisation_repository.py
-- app/db/session.py
-- tests/fixtures/db.py
-"""
+from app.db.seed import OrganisationSeed, SeedPlan, seed_from_plan, seed_minimal
+from app.repositories.organisation_repository import OrganisationRepository
+
+pytestmark = pytest.mark.integration
+
+
+def test_seed_minimal_idempotent(db_session: Session) -> None:
+    """Applying the minimal seed twice should not create duplicates."""
+
+    organisation_name = "Acme FC"
+    first_result = seed_minimal(db_session, org_name=organisation_name)
+    assert first_result["inserted"] >= 1
+    assert first_result["updated"] == 0
+    second_result = seed_minimal(db_session, org_name=organisation_name)
+    assert second_result["inserted"] == 0
+    assert second_result["updated"] == 0
+    assert second_result["skipped"] >= 1
+
+
+def test_seed_minimal_dry_run_matches_apply(db_session: Session) -> None:
+    """A dry-run should report the same actions as an actual apply."""
+
+    repository = OrganisationRepository()
+    organisation_name = "Acme FC Dry Run"
+    plan = SeedPlan(organisations=(OrganisationSeed(name=organisation_name),))
+
+    dry_run_summary: set[tuple[str | None, str | None]] = set()
+    dry_run_transaction = db_session.begin_nested()
+    try:
+        dry_run_result = seed_from_plan(db_session, plan)
+        assert dry_run_result["inserted"] == 1
+        dry_run_summary = {
+            (item.get("name"), item.get("slug")) for item in dry_run_result["items"]
+        }
+    finally:
+        dry_run_transaction.rollback()
+
+    assert repository.get_by_name(db_session, organisation_name) is None
+
+    apply_result = seed_from_plan(db_session, plan)
+    assert apply_result["inserted"] == 1
+    apply_summary = {
+        (item.get("name"), item.get("slug")) for item in apply_result["items"]
+    }
+    assert dry_run_summary == apply_summary
+
+    repeat_result = seed_from_plan(db_session, plan)
+    assert repeat_result["inserted"] == 0
+    assert repeat_result["skipped"] >= 1
+
+
+def test_seed_minimal_duplicate_name_raises(db_session: Session) -> None:
+    """Direct repository usage should raise when attempting duplicate inserts."""
+
+    repository = OrganisationRepository()
+    name = "Seed Duplicate"
+    repository.create(db_session, name=name)
+    with pytest.raises(IntegrityError):
+        repository.create(db_session, name=name)
+    db_session.rollback()


### PR DESCRIPTION
## Summary
- add transactional SQLAlchemy fixtures for integration tests and optional migration helper
- introduce deterministic time-freezing fixture for UTC-aware tests
- cover database connectivity, migrations, repository behaviour, and seeding routines with integration tests

## Testing
- `ruff check tests/fixtures/db.py tests/fixtures/time.py tests/integration/test_db_connect.py tests/integration/test_migrations.py tests/integration/test_repositories.py tests/integration/test_seed_data.py`
- `mypy tests/fixtures/db.py tests/fixtures/time.py tests/integration/test_db_connect.py tests/integration/test_migrations.py tests/integration/test_repositories.py tests/integration/test_seed_data.py` *(fails: mypy.ini invalid pattern `[mypy-psycopg*]`)*
- `SKIP_ALL_TESTS=0 pytest -q -m integration` *(fails during collection: Pydantic BaseModel config raises `TypeError: 'bool' object cannot be converted to 'PyString'`)*

------
https://chatgpt.com/codex/tasks/task_e_68d4f04be75c83259ac4bb46032dd8d3